### PR TITLE
feat: auto load stations on StationHelper init

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ To get the timetable of a specific train station you can use the name or lat and
 
 ```python
 station_helper = StationHelper()
-station_helper.load_stations()
 found_stations = station_helper.find_stations_by_lat_long(47.996713, 7.842174, 10)
 found_stations_by_name = station_helper.find_stations_by_name("Freiburg")
 ```

--- a/deutsche_bahn_api/station_helper.py
+++ b/deutsche_bahn_api/station_helper.py
@@ -20,8 +20,12 @@ class StationHelper:
 
     def __init__(self) -> None:
         self.stations_list = []
+        self.load_stations()
 
     def load_stations(self):
+        if len(self.stations_list) > 0:
+            return
+
         json_raw = pkgutil.get_data(__name__, "static/train_stations_list.json")
         stations = json.loads(json_raw)
         for item in stations:
@@ -49,4 +53,3 @@ class StationHelper:
                 results.append(station)
 
         return results
-


### PR DESCRIPTION
As the name suggests. With this PR, the stations are loaded automatically when the `StationHelper` class is initialised, allowing you to omit the annoying `station_helper.load_stations()` in your code. To use the class, you _need_ to call this method right after initialisation, so it makes sense to move it to the constructor.

With these changes, the library should still be backwards compatible without any performance loss.
