### PR TITLE
Fixed to allow wildcard import (*)

### DIFF
--- a/deutsche_bahn_api/__init__.py
+++ b/deutsche_bahn_api/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["api_authentication", "deutsche_bahn_api", "message", "station_helper", "station", "timetable_helper", "train_changes", "train"]


### PR DESCRIPTION
A minor contribution that allows you to do:

`from deutsche_bahn_api import *`

as mentioned in Issue #8.
