### PR TITLE
Fix dependencies and add some more informations to stop data

### DIFF
--- a/deutsche_bahn_api/api_authentication.py
+++ b/deutsche_bahn_api/api_authentication.py
@@ -13,7 +13,6 @@ class ApiAuthentication:
                 "DB-Api-Key": self.client_secret,
                 "DB-Client-Id": self.client_id,
             },
-            verify=False
         )
         return response.status_code == 200
 

--- a/deutsche_bahn_api/api_authentication.py
+++ b/deutsche_bahn_api/api_authentication.py
@@ -12,7 +12,8 @@ class ApiAuthentication:
             headers={
                 "DB-Api-Key": self.client_secret,
                 "DB-Client-Id": self.client_id,
-            }
+            },
+            verify=False
         )
         return response.status_code == 200
 

--- a/deutsche_bahn_api/station_helper.py
+++ b/deutsche_bahn_api/station_helper.py
@@ -1,6 +1,6 @@
 import json
 import pkgutil
-import mpu
+from haversine import haversine
 
 from deutsche_bahn_api.station import Station
 
@@ -37,7 +37,7 @@ class StationHelper:
         for station in self.stations_list:
             lat_long: dict[str, float] = normalize_lat_or_long_from_station(station)
 
-            distance = mpu.haversine_distance(
+            distance = haversine(
                 (lat_long['lat'], lat_long['long']),
                 (target_lat, target_long))
             if distance < radius:

--- a/deutsche_bahn_api/station_helper.py
+++ b/deutsche_bahn_api/station_helper.py
@@ -53,3 +53,8 @@ class StationHelper:
                 results.append(station)
 
         return results
+
+    def find_station_by_id(self, query: int) -> list[Station]:
+        for station in self.stations_list:
+            if query == station.EVA_NR:
+                return station

--- a/deutsche_bahn_api/station_helper.py
+++ b/deutsche_bahn_api/station_helper.py
@@ -54,7 +54,22 @@ class StationHelper:
 
         return results
 
-    def find_station_by_id(self, query: int) -> list[Station]:
+    def find_stations_by_id(self, query: int) -> list[Station]:
+        results: list[Station] = []
+
         for station in self.stations_list:
             if query == station.EVA_NR:
-                return station
+                results.append(station)
+
+        return results
+    
+    def find_station_by_id(self, query: int) -> list[Station]:
+        results: list[Station] = []
+        for station in self.stations_list:
+            if query == station.EVA_NR:
+                results.append(station)
+
+        if len(results)>1:
+            raise Exception("More than one station with id '%s' found" % query)
+        else:
+            return results[0]

--- a/deutsche_bahn_api/timetable_helper.py
+++ b/deutsche_bahn_api/timetable_helper.py
@@ -114,12 +114,16 @@ class TimetableHelper:
                         train_changes.stations = changes.attrib["cpth"]
                     if "cp" in changes.attrib:
                         train_changes.platform = changes.attrib["cp"]
+                    if "cs" in changes.attrib:
+                        train_changes.departure_cancelled = changes.attrib["cs"]
 
                 if changes.tag == "ar":
                     if "ct" in changes.attrib:
                         train_changes.arrival = changes.attrib["ct"]
                     if "cpth" in changes.attrib:
                         train_changes.passed_stations = changes.attrib["cpth"]
+                    if "cs" in changes.attrib:
+                        train_changes.arrival_cancelled = changes.attrib["cs"]
 
                 for message in changes:
                     new_message = Message()

--- a/deutsche_bahn_api/timetable_helper.py
+++ b/deutsche_bahn_api/timetable_helper.py
@@ -44,9 +44,9 @@ class TimetableHelper:
                             .format(response.status_code, response.text))
         return response.text
 
-    def get_timetable(self, hour: Optional[int] = None) -> list[Train]:
+    def get_timetable(self, hour: Optional[int] = None, date: Optional[datetime] = None) -> list[Train]:
         train_list: list[Train] = []
-        trains = elementTree.fromstringlist(self.get_timetable_xml(hour))
+        trains = elementTree.fromstringlist(self.get_timetable_xml(hour, date))
         for train in trains:
             trip_label_object: dict[str, str] | None = None
             arrival_object: dict[str, str] | None = None

--- a/deutsche_bahn_api/timetable_helper.py
+++ b/deutsche_bahn_api/timetable_helper.py
@@ -67,15 +67,23 @@ class TimetableHelper:
             train_object.stop_id = train.attrib["id"]
             train_object.train_type = trip_label_object["c"]
             train_object.train_number = trip_label_object["n"]
-            train_object.platform = departure_object['pp']
-            train_object.stations = departure_object['ppth']
-            train_object.departure = departure_object['pt']
+            if departure_object:
+                train_object.platform = departure_object['pp']
+                train_object.stations = departure_object['ppth']
+                train_object.departure = departure_object['pt']
+                if "l" in departure_object:
+                    train_object.train_line = departure_object['l']
+            else:
+                train_object.platform = arrival_object['pp']
+                train_object.stations = arrival_object['ppth']
+                train_object.departure = arrival_object['pt']
+                if "l" in arrival_object:
+                    train_object.train_line = arrival_object['l']                
 
             if "f" in trip_label_object:
                 train_object.trip_type = trip_label_object["f"]
 
-            if "l" in departure_object:
-                train_object.train_line = departure_object['l']
+
 
             if arrival_object:
                 train_object.passed_stations = arrival_object['ppth']
@@ -122,6 +130,8 @@ class TimetableHelper:
                         train_changes.arrival = changes.attrib["ct"]
                     if "cpth" in changes.attrib:
                         train_changes.passed_stations = changes.attrib["cpth"]
+                    if "cp" in changes.attrib:
+                        train_changes.platform = changes.attrib["cp"]
                     if "cs" in changes.attrib:
                         train_changes.arrival_cancelled = changes.attrib["cs"]
 

--- a/deutsche_bahn_api/timetable_helper.py
+++ b/deutsche_bahn_api/timetable_helper.py
@@ -75,8 +75,6 @@ class TimetableHelper:
                     train_object.train_line = departure_object['l']
             else:
                 train_object.platform = arrival_object['pp']
-                train_object.stations = arrival_object['ppth']
-                train_object.departure = arrival_object['pt']
                 if "l" in arrival_object:
                     train_object.train_line = arrival_object['l']                
 

--- a/deutsche_bahn_api/timetable_helper.py
+++ b/deutsche_bahn_api/timetable_helper.py
@@ -59,9 +59,9 @@ class TimetableHelper:
                 if train_details.tag == "ar":
                     arrival_object = train_details.attrib
 
-            if not departure_object:
-                """ Arrival without department """
-                continue
+#            if not departure_object:
+#                """ Arrival without department """
+#                continue
 
             train_object: Train = Train()
             train_object.stop_id = train.attrib["id"]

--- a/deutsche_bahn_api/timetable_helper.py
+++ b/deutsche_bahn_api/timetable_helper.py
@@ -59,20 +59,18 @@ class TimetableHelper:
                 if train_details.tag == "ar":
                     arrival_object = train_details.attrib
 
-#            if not departure_object:
-#                """ Arrival without department """
-#                continue
-
             train_object: Train = Train()
             train_object.stop_id = train.attrib["id"]
             train_object.train_type = trip_label_object["c"]
             train_object.train_number = trip_label_object["n"]
+            # If Stop has departure_object, get some informations from it
             if departure_object:
                 train_object.platform = departure_object['pp']
                 train_object.stations = departure_object['ppth']
                 train_object.departure = departure_object['pt']
                 if "l" in departure_object:
                     train_object.train_line = departure_object['l']
+            # If not, get them from arrival_object
             else:
                 train_object.platform = arrival_object['pp']
                 if "l" in arrival_object:

--- a/deutsche_bahn_api/timetable_helper.py
+++ b/deutsche_bahn_api/timetable_helper.py
@@ -89,7 +89,8 @@ class TimetableHelper:
     def get_timetable_changes(self, trains: list) -> list[Train]:
         response = requests.get(
             f"https://apis.deutschebahn.com/db-api-marketplace/apis/timetables/v1/fchg/{self.station.EVA_NR}",
-            headers=self.api_authentication.get_headers()
+            headers=self.api_authentication.get_headers(),
+            verify=False
         )
         changed_trains = elementTree.fromstringlist(response.text)
 

--- a/deutsche_bahn_api/timetable_helper.py
+++ b/deutsche_bahn_api/timetable_helper.py
@@ -32,7 +32,8 @@ class TimetableHelper:
         response = requests.get(
             f"https://apis.deutschebahn.com/db-api-marketplace/apis/timetables/v1"
             f"/plan/{self.station.EVA_NR}/{date_string}/{hour}",
-            headers=self.api_authentication.get_headers()
+            headers=self.api_authentication.get_headers(),
+            verify=False
         )
         if response.status_code == 410:
             return self.get_timetable_xml(int(hour), datetime.now() + timedelta(days=1))

--- a/deutsche_bahn_api/timetable_helper.py
+++ b/deutsche_bahn_api/timetable_helper.py
@@ -46,7 +46,7 @@ class TimetableHelper:
 
     def get_timetable(self, hour: Optional[int] = None, date: Optional[datetime] = None) -> list[Train]:
         train_list: list[Train] = []
-        trains = elementTree.fromstringlist(self.get_timetable_xml(hour, date))
+        trains = elementTree.fromstringlist(self.get_timetable_xml(hour=hour, date=date))
         for train in trains:
             trip_label_object: dict[str, str] | None = None
             arrival_object: dict[str, str] | None = None

--- a/deutsche_bahn_api/timetable_helper.py
+++ b/deutsche_bahn_api/timetable_helper.py
@@ -94,8 +94,7 @@ class TimetableHelper:
     def get_timetable_changes(self, trains: list) -> list[Train]:
         response = requests.get(
             f"https://apis.deutschebahn.com/db-api-marketplace/apis/timetables/v1/fchg/{self.station.EVA_NR}",
-            headers=self.api_authentication.get_headers(),
-            verify=False
+            headers=self.api_authentication.get_headers()
         )
         changed_trains = elementTree.fromstringlist(response.text)
 

--- a/deutsche_bahn_api/timetable_helper.py
+++ b/deutsche_bahn_api/timetable_helper.py
@@ -33,7 +33,6 @@ class TimetableHelper:
             f"https://apis.deutschebahn.com/db-api-marketplace/apis/timetables/v1"
             f"/plan/{self.station.EVA_NR}/{date_string}/{hour}",
             headers=self.api_authentication.get_headers(),
-            verify=False
         )
         if response.status_code == 410:
             return self.get_timetable_xml(int(hour), datetime.now() + timedelta(days=1))

--- a/deutsche_bahn_api/train_changes.py
+++ b/deutsche_bahn_api/train_changes.py
@@ -9,3 +9,5 @@ class TrainChanges:
     stations: str
     platform: str
     messages: list[Message]
+    arrival_cancelled: bool
+    departure_cancelled: bool

--- a/deutsche_bahn_api/train_changes.py
+++ b/deutsche_bahn_api/train_changes.py
@@ -9,5 +9,5 @@ class TrainChanges:
     stations: str
     platform: str
     messages: list[Message]
-    arrival_cancelled: bool
-    departure_cancelled: bool
+    arrival_cancelled: str
+    departure_cancelled: str

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/Tutorialwork/deutsche_bahn_api",
     packages=find_packages(),
-    install_requires=["mpu", "requests"],
+    install_requires=["haversine", "requests"],
     package_data={"deutsche_bahn_api": ["static/*"]},
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/test.py
+++ b/test.py
@@ -1,7 +1,0 @@
-import deutsche_bahn_api.api_authentication as dba
-import deutsche_bahn_api.timetable_helper as dbt
-import deutsche_bahn_api.station_helper as dbc_s
-
-api = dba.ApiAuthentication("1ac3d18ab81777747efe5f41b6b78ca5", "076006a97b68f3fd1c914ede788c443f")
-station_helper = dbc_s.StationHelper()
-print(station_helper.find_stations_by_lat_long(48.209166953908536, 11.34949095056929, 2))

--- a/test.py
+++ b/test.py
@@ -1,0 +1,7 @@
+import deutsche_bahn_api.api_authentication as dba
+import deutsche_bahn_api.timetable_helper as dbt
+import deutsche_bahn_api.station_helper as dbc_s
+
+api = dba.ApiAuthentication("1ac3d18ab81777747efe5f41b6b78ca5", "076006a97b68f3fd1c914ede788c443f")
+station_helper = dbc_s.StationHelper()
+print(station_helper.find_stations_by_lat_long(48.209166953908536, 11.34949095056929, 2))


### PR DESCRIPTION
Hi,

- Fix: Replace MPU to remove deprecation warning:
`lib/python3.13/site-packages/mpu/string.py:16: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources`
- Get plattform data from arrival object if departure object does not exist
- Add arrival/departure cancelled information